### PR TITLE
Creating catalog-info.yaml for Backstage Auto Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.env
+catalog-info-example.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,6 +12,9 @@ metadata:
     - docker
     - otel
     - o11y
+    - observability
+    - demo
+    - opensource
   links:
     - url: https://github.com/liatrio/o11y-demo
       icon: dashboard

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,33 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: o11y demo
+  # description: Add a useful description before merging
+
+  # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
+  annotations:
+    github.com/project-slug: liatrio/o11y-demo
+
+  # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
+  # tags:
+  #   - example
+  #   - tag
+
+  # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
+  # links:
+  #   - url: https://example.com/user
+  #     title: Examples Users
+  #     icon: user
+  #   - url: https://example.com/group
+  #     title: Example Group
+  #     icon: group
+
+spec:
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
+  type: service
+  # Review lifecycle and pick one of the three that make the most sense.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
+  lifecycle: production
+  # Please update to include the GitHub Team name tied to this project.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
+  owner: liatrio-team-members

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: o11y demo
+  name: o11y-demo
   # description: Add a useful description before merging
 
   # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,33 +1,22 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: o11y-demo
-  # description: Add a useful description before merging
-
-  # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
+  name: O11y-Demo
+  description: This is a self contained demo of the Liatrio OpenTelemetry Collector and Grafana using Prometheus as the data source. The intent of this demo is to show how to use the Liatrio OpenTelemetry Collector to scrape data from GitHub and expose it to Grafana for visualization. This demo is not intended to be used in production.
   annotations:
-    github.com/project-slug: liatrio/o11y-demo
-
-  # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
-  # tags:
-  #   - example
-  #   - tag
-
-  # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
-  # links:
-  #   - url: https://example.com/user
-  #     title: Examples Users
-  #     icon: user
-  #   - url: https://example.com/group
-  #     title: Example Group
-  #     icon: group
-
+    github.com/project-slug: 'liatrio/o11y-demo'
+    backstage.io/techdocs-ref: 'url:https://github.com/liatrio/o11y-demo'
+  tags:
+    - prometheus
+    - grafana
+    - docker
+    - otel
+    - o11y
+  links:
+    - url: https://github.com/liatrio/o11y-demo
+      icon: dashboard
 spec:
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
   type: service
-  # Review lifecycle and pick one of the three that make the most sense.
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
-  lifecycle: production
-  # Please update to include the GitHub Team name tied to this project.
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
-  owner: liatrio-team-members
+  lifecycle: demo
+  owner: o11y-owners
+  system: o11y-demo


### PR DESCRIPTION
❗ This is not ready to merge. Please review the changeset and update based on your repository. ❗

Please give the catalog-info.yaml a review. It could use tags, links, a description and the correct owner. Each section has links to the related documentation.

Review the [catalog-info.yaml docs](https://backstage.io/docs/features/software-catalog/descriptor-format/)
Check out an example of our implementation in [gratibot](https://github.com/liatrio/gratibot/blob/main/catalog-info.yaml)

After you've finished and merged, this repository will auto discover in the Liatrio Backstage instance.

For any questions, please reach out on our Slack channel: #project-backstage-foundations